### PR TITLE
Classify composer.lock as binary, add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset=utf-8
+end_of_line=lf
+trim_trailing_whitespace=true
+insert_final_newline=true
+indent_style=space
+indent_size=4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 * text=auto
 *.css linguist-vendored
 *.scss linguist-vendored
+
+*.lock binary
+
+public/js/*.js binary
+public/css/*.css binary


### PR DESCRIPTION
In a previous PR (https://github.com/RumiaGIT/svhelloworld/pull/35) I noticed that I had added and removed thousands of lines, this was because of an update in the `composer.lock`.

A `composer.lock` should never be compared by git using the diff method. It should be handled like a binary. The `.gitattributes` config file achieves that. Git will now handle lockfiles as binaries, and replace them entirely in a merge.

I also decided to add an `.editorconfig` file, as I also noticed that was missing from the project.